### PR TITLE
Removed Port from default CLIARGS, allowing usage of different server…

### DIFF
--- a/root/etc/services.d/minetest/run
+++ b/root/etc/services.d/minetest/run
@@ -2,4 +2,4 @@
 
 exec \
 	s6-setuidgid abc minetestserver ${CLI_ARGS} \
-	--config /config/.minetest/main-config/minetest.conf --port 30000
+	--config /config/.minetest/main-config/minetest.conf


### PR DESCRIPTION
Hi Jordan, thank you for providing the version with postgresql support. I've just migrated my server to this docker version (leveldb to postgresql migration took over 6 hours 😄) as I wanted to use the great [mapserver](https://github.com/minetest-mapserver/mapserver).

As my server is running on port 30001 since 2014 and I don't want to change the port now. The default argument in the startup command overwrites the port which is defined in minetest.conf. Please consider merging this change, to remove the unnecessary parameter. 